### PR TITLE
[WIP] add some tests for running w/ containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD demo/inventory /runner/inventory
 # Install Ansible and Runner
 ADD https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo /etc/yum.repos.d/ansible-runner.repo
 RUN dnf install -y epel-release && \
-    dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en && \
+    dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en git && \
     alternatives --set python /usr/bin/python3 && \
     pip3 install ansible && \
     chmod +x /bin/tini /bin/entrypoint && \
@@ -21,15 +21,16 @@ RUN mkdir -p /runner/inventory /runner/project /runner/artifacts /runner/.ansibl
 	chmod -R g+w /runner && chgrp -R root /runner && \
 	chmod g+w /etc/passwd
 
-VOLUME /runner/inventory
-VOLUME /runner/project
-VOLUME /runner/artifacts
+VOLUME /runner
 
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 ENV RUNNER_BASE_COMMAND=ansible-playbook
 ENV HOME=/runner
+
+ENV ANSIBLE_STDOUT_CALLBACK=awx_display
+ENV ANSIBLE_CALLBACK_PLUGINS=/usr/lib/python3.6/site-packages/ansible_runner/callbacks
 
 WORKDIR /runner
 

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -84,7 +84,7 @@ class RunnerConfig(object):
                  resource_profiling_results_dir=None,
                  tags=None, skip_tags=None, fact_cache_type='jsonfile', fact_cache=None, ssh_key=None,
                  project_dir=None, directory_isolation_base_path=None, envvars=None, forks=None, cmdline=None, omit_event_data=False,
-                 only_failed_event_data=False):
+                 only_failed_event_data=False, containerized=False, container_runtime=False):
         self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = str(ident)
         self.json_mode = json_mode
@@ -142,6 +142,8 @@ class RunnerConfig(object):
         self.cmdline_args = cmdline
         self.omit_event_data = omit_event_data
         self.only_failed_event_data = only_failed_event_data
+        self.containerized = containerized
+        self.container_runtime = container_runtime
 
     def prepare(self):
         """

--- a/test/integration/containerized/conftest.py
+++ b/test/integration/containerized/conftest.py
@@ -1,0 +1,88 @@
+import json
+import os
+import sys
+import subprocess
+import yaml
+
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+
+@pytest.fixture
+def tmp_file_maker():
+    """Fixture to return temporary file maker."""
+    def tmp_file(text):
+        with NamedTemporaryFile(delete=False) as tempf:
+            tempf.write(bytes(text, 'UTF-8'))
+        return tempf.name
+    return tmp_file
+
+
+class CompletedProcessProxy(object):
+
+    def __init__(self, result):
+        self.result = result
+
+    def __getattr__(self, attr):
+        return getattr(self.result, attr)
+
+    @property
+    def json(self):
+        try:
+            response_json = json.loads(self.stdout)
+        except json.JSONDecodeError:
+            pytest.fail(
+                f"Unable to convert the response to a valid json - stdout: {self.stdout}, stderr: {self.stderr}"
+            )
+        return response_json
+
+    @property
+    def yaml(self):
+        return yaml.safe_load(self.stdout)
+
+
+@pytest.fixture(autouse=True, scope='session')
+def ansible_runner_binary():
+    if not os.environ.get('POETRY_ACTIVE', False):
+        return 'ansible-runner'
+    syspath = os.environ.get('PATH').split(':')
+    venv_index = None
+    for item in syspath:
+        if 'pypoetry' in item:
+            venv_index = syspath.index(item)
+            break
+    if venv_index is None:
+        pytest.fail('poetry is active but cannot find its venv')
+
+    venv_bin = syspath.pop(venv_index)
+    return os.path.join(venv_bin, 'ansible-runner')
+
+
+@pytest.fixture(scope='function')
+def cli(request, ansible_runner_binary):
+    def run(args, *a, **kw):
+        args = [ansible_runner_binary,] + args
+        kw['encoding'] = 'utf-8'
+        if 'check' not in kw:
+            # By default we want to fail if a command fails to run. Tests that
+            # want to skip this can pass check=False when calling this fixture
+            kw['check'] = True
+        if 'stdout' not in kw:
+            kw['stdout'] = subprocess.PIPE
+        if 'stderr' not in kw:
+            kw['stderr'] = subprocess.PIPE
+
+            kw.setdefault('env', {}).update({
+                'LANG': 'en_US.UTF-8'
+            })
+
+        try:
+            ret = CompletedProcessProxy(subprocess.run(args, *a, **kw))
+        except subprocess.CalledProcessError as err:
+            pytest.fail(
+                f"Running {err.cmd} resulted in a non-zero return code: {err.returncode} - stdout: {err.stdout}, stderr: {err.stderr}"
+            )
+
+        return ret
+    return run

--- a/test/integration/containerized/priv_data/env/extravars
+++ b/test/integration/containerized/priv_data/env/extravars
@@ -1,0 +1,2 @@
+---
+ansible_connection: local

--- a/test/integration/containerized/priv_data/env/settings
+++ b/test/integration/containerized/priv_data/env/settings
@@ -1,0 +1,6 @@
+---
+idle_timeout: 60
+job_timeout: 360
+pexpect_timeout: 10
+containerized: true
+container_runtime: docker

--- a/test/integration/containerized/priv_data/inventory/hosts
+++ b/test/integration/containerized/priv_data/inventory/hosts
@@ -1,0 +1,1 @@
+localhost

--- a/test/integration/containerized/priv_data/project/test-container.yml
+++ b/test/integration/containerized/priv_data/project/test-container.yml
@@ -1,0 +1,39 @@
+---
+- hosts: localhost
+  gather_facts: yes
+  vars:
+    cgroup_search_terms: docker\|lxc\|podman\|oci
+    is_container: false
+    is_podman: false
+    is_docker: false
+  tasks:
+    - debug: msg="Test if we are in a container!"
+
+    - name: 'Look container env var defined in /proc/1/environ'
+      shell: "grep 'container=' /proc/1/environ"
+      register: container_proc_environ
+      ignore_errors: yes
+
+    - name: 'Look container info defined in /proc/1/cgroup'
+      shell: "grep '{{ cgroup_search_terms}}' /proc/1/cgroup"
+      register: container_proc_cgroup
+      ignore_errors: yes
+
+    - name: 'Found evidence that we are in docker container'
+      set_fact:
+        is_docker: true
+      when: (('container' in ansible_env and ansible_env.container == 'docker') or ansible_virtualization_type == 'docker')
+
+    - name: 'Found evidence that we are in podman container'
+      set_fact:
+        is_podman: true
+      when: ('container' in ansible_env and ansible_env.container == 'podman')
+
+    - name: 'Found evidence that we are in a container'
+      set_fact:
+        is_container: true
+      when: is_docker or is_podman or container_proc_environ.rc == 0 or container_proc_cgroup.rc == 0
+
+    - fail:
+      when: not (is_container)
+

--- a/test/integration/containerized/test_cli_containerized.py
+++ b/test/integration/containerized/test_cli_containerized.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+import os
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+def test_module_run(cli):
+    cli(['-m', 'ping','--hosts', 'localhost', 'run', os.path.join(HERE, 'priv_data')])
+
+def test_playbook_run(cli):
+    cli(['run', os.path.join(HERE,'priv_data'), '-p', 'test-container.yml'])
+


### PR DESCRIPTION
This is a very rough idea of how I might write tests, some problems need to be resolved before considering mergable, but might be cool if you want to run these tests locally. These will probably not work on zuul as they are written today.

Known issues:
  - what image? I have manually hacked `ansible_runner/runner_config.py` to use an image I built from this branch
  - how to clean up?  currently the jobs run in the container are producing files owned by root (job events and .ansible directory) this is trashy, would like all this to happen in a temp directory -- this is general problem w/ this test suite
  - when/where to run? @alancoding really wants us to run tests w/ containers @matburt also seems amenable, @shanemcd is very concerned about CI runtime which is reasonable -- we are already at 15 min (although tests take up only 5 min).
    - as far as this question goes, I'm open to different options but I really want the TESTS to be here in the `ansible-runner` repo and to make it a native part of development cycle to be able to run integration tests that actually run the CLI and that use containers.
     - with the current tests currently take 15 min we have a lot of time to work with if we can work in parallel. Would be interesting to see what we can do during those 15 min. We do have option of the github workflows which are quite snappy seeing as this is an opensource project.
  - how to deal with different container runtimes? This will depend on the system the tests are running on, probably need to allow tests to skip based on availablity of container run times to test with.